### PR TITLE
Provide Psycopg Subclasses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,27 @@ or
     connection = db_api_compatible_client.connect(...)
     tracing = ConnectionTracing(connection)
 
+For expanded usage with Psycopg connection factories, a ``PsycopgConnectionTracing`` class is also available.  This
+is necessary for directly using extensions and extras functions on traced connections.  Its non-default usage requires a
+lambda proxy or closure to account for the expected tracing arguments, while using the global tracer and default allow
+it to be passed directly:
+
+ .. code-block:: python
+
+    from dbapi_opentracing import PsycopgConnectionTracing
+    import opentracing
+    import psycopg2
+
+    opentracing_tracer = ## some OpenTracing tracer implementation
+    my_tags = dict(some='tag')
+    tracing = psycopg2.connect(
+        ..., connection_factory=lambda dsn: PsycopgConnectionTracing(dsn, tracer=opentracing_tracer, span_tags=my_tags)
+    )
+
+    # or to use all defaults
+    opentracing.tracer = opentracing_tracer
+    tracing = psycopg2.connect(..., connection_factory=PsycopgConnectionTracing)
+
 ConnectionTracing Configuration
 -------------------------------
 

--- a/dbapi_opentracing/__init__.py
+++ b/dbapi_opentracing/__init__.py
@@ -1,1 +1,2 @@
 from .tracing import ConnectionTracing, Cursor  # noqa
+from .psycopg2_tracing import PsycopgConnectionTracing  # noqa

--- a/dbapi_opentracing/psycopg2_tracing.py
+++ b/dbapi_opentracing/psycopg2_tracing.py
@@ -1,0 +1,182 @@
+from threading import Lock
+
+from .tracing import _ConnectionTracing, _Cursor, _operation_name
+
+try:
+    from psycopg2.extensions import connection as PsycopgConnection
+    from psycopg2.extensions import cursor as PsycopgCursor
+except ImportError:
+    PsycopgConnection = object
+    PsycopgCursor = object
+
+
+class _PsycopgCursorTracing(_Cursor):
+    """
+    Traced mixin for subclass of psycopg2 cursor.  Intended to be used by connection.cursor(cursor_factory).
+    """
+    def __init__(self, cursor_factory, tracer=None, span_tags=None, trace_execute=True, trace_executemany=True,
+                 trace_callproc=True, *args, **kwargs):
+        _Cursor.__init__(self, tracer=tracer, span_tags=span_tags, trace_execute=trace_execute,
+                         trace_executemany=trace_executemany, trace_callproc=trace_callproc)
+        # Since we should support any psycopg cursor type, proxy methods for traced execution
+        self._cursor_factory = cursor_factory
+
+    def _get_statement(self, args):
+        if isinstance(args[1], bytes):
+            arg = args[1].decode('utf8', 'replace')
+        else:
+            arg = args[1]
+        return arg.split(' ')[0]
+
+    def _get_query(self, args):
+        return self._format_query(args[1])
+
+    def execute(self, *args, **kwargs):
+        if not self._self_trace_execute:
+            return self._cursor_factory.execute(self, *args, **kwargs)
+
+        return self._traced_execution(self._cursor_factory.execute, self, *args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        if not self._self_trace_executemany:
+            return self._cursor_factory.executemany(self, *args, **kwargs)
+
+        return self._traced_execution(self._cursor_factory.executemany, self, *args, **kwargs)
+
+    def callproc(self, *args, **kwargs):
+        if not self._self_trace_callproc:
+            return self._cursor_factory.callproc(self, *args, **kwargs)
+
+        return self._traced_execution(self._cursor_factory.callproc, self, *args, **kwargs)
+
+
+# Storage for CursorFactory classes to prevent redundant definitions
+_cursor_factory_classes = {}
+_cursor_factory_lock = Lock()
+
+
+class PsycopgCursorTracing(object):
+    """
+    Traced psycopg cursor_factory-compatible pseudo-metaclass, which generates and instantiates traced
+    cursor_factory subclass.
+    """
+    def __new__(cls, *args, **kwargs):
+        factory = kwargs.pop('cursor_factory', PsycopgCursor)
+        with _cursor_factory_lock:
+            if factory not in _cursor_factory_classes:
+
+                class CursorFactory(_PsycopgCursorTracing, factory):
+                    """Traced cursor_factory instance."""
+                    def __init__(self, conn, *a, **kw):
+                        # Pop all _PsycopgCursorTracing tracing flags to be able to
+                        # pass custom cursor factory (kw)args
+                        _PsycopgCursorTracing.__init__(
+                            self, cursor_factory=factory,
+                            tracer=kw.pop('tracer', None),
+                            span_tags=kw.pop('span_tags', None),
+                            trace_execute=kw.pop('trace_execute', True),
+                            trace_executemany=kw.pop('trace_executemany', True),
+                            trace_callproc=kw.pop('trace_callproc', True)
+                        )
+                        factory.__init__(self, conn, *a, **kw)
+
+                CursorFactory.__name__ = factory.__name__
+                _cursor_factory_classes[factory] = CursorFactory
+
+        return _cursor_factory_classes[factory](*args, **kwargs)
+
+
+class _PsycopgConnectionTracing(_ConnectionTracing):
+    """
+    Traced mixin for psycopg2 connection.  `connection_factory` should be provided as invoking classes' psycopg
+    connection superclass (psycopg.extensions.connection as default) for proxying traced commit and cursor.
+    """
+    def __init__(self, dsn, connection_factory=PsycopgConnection, cursor_factory=PsycopgCursor, tracer=None,
+                 span_tags=None, trace_commit=True, trace_rollback=True, trace_execute=True, trace_executemany=True,
+                 trace_callproc=True, *args, **kwargs):
+        _ConnectionTracing.__init__(
+            self, tracer=tracer, span_tags=span_tags, trace_commit=trace_commit, trace_rollback=trace_rollback,
+            trace_execute=trace_execute, trace_executemany=trace_executemany, trace_callproc=trace_callproc
+        )
+        self._connection_factory = connection_factory
+        self._cursor_factory = cursor_factory
+
+        self._commit_operation_name = _operation_name(self, self.commit)
+        self._rollback_operation_name = _operation_name(self, self.rollback)
+
+    def cursor(self, name=None, *args, **kwargs):
+        trace_execute = kwargs.pop('trace_execute', self._self_trace_execute)
+        trace_executemany = kwargs.pop('trace_executemany', self._self_trace_executemany)
+        trace_callproc = kwargs.pop('trace_callproc', self._self_trace_callproc)
+
+        cursor_factory = kwargs.pop('cursor_factory', self._cursor_factory)
+        return PsycopgCursorTracing(conn=self, name=name, cursor_factory=cursor_factory, tracer=self._self_tracer,
+                                    span_tags=self._self_span_tags, trace_execute=trace_execute,
+                                    trace_executemany=trace_executemany, trace_callproc=trace_callproc, *args, **kwargs)
+
+    def commit(self):
+        if not self._self_trace_commit:
+            return self._connection_factory.commit(self)
+
+        return self._traced_execution(self._commit_operation_name, self._connection_factory.commit, self)
+
+    def rollback(self):
+        if not self._self_trace_rollback:
+            return self._connection_factory.rollback(self)
+
+        return self._traced_execution(self._rollback_operation_name, self._connection_factory.rollback, self)
+
+
+# Storage for ConnectionFactory classes to prevent redundant definitions
+_connection_factory_classes = {}
+_connection_factory_lock = Lock()
+
+
+class PsycopgConnectionTracing(object):
+    """
+    Traced psycopg connection_factory-compatible pseudo-metaclass, which generates and instantiates traced
+    connection_factory subclass.
+
+    connection = psycopg2.connect(dsn, connection_factory=PsycopgConnectionTracing)
+    assert isinstance(connection, psycopg2.extensions.connection)
+
+    or
+
+    connection = psycopg2.connect(
+        dsn, connection_factory=lambda dsn: PsycopgConnectionTracing(
+            dsn, connection_factory=LogicalReplicationConnection
+        )
+    )
+    assert isinstance(connection, LogicalReplicationConnection)
+    """
+    def __new__(cls, *args, **kwargs):
+        factory = kwargs.pop('connection_factory', PsycopgConnection)
+
+        with _connection_factory_lock:
+            if factory not in _cursor_factory_classes:
+
+                class ConnectionFactory(_PsycopgConnectionTracing, factory):
+
+                    def __init__(self, dsn, *a, **kw):
+                        # Pop all _PsycopgConnectionTracing tracing flags to be able to
+                        # pass custom connection factory (kw)args
+                        pct_args = dict(
+                            dsn=dsn, connection_factory=factory,
+                            tracer=kw.pop('tracer', None),
+                            span_tags=kw.pop('span_tags', None),
+                            trace_commit=kw.pop('trace_commit', True),
+                            trace_rollback=kw.pop('trace_rollback', True),
+                            trace_execute=kw.pop('trace_execute', True),
+                            trace_executemany=kw.pop('trace_executemany', True),
+                            trace_callproc=kw.pop('trace_callproc', True)
+                        )
+                        if 'cursor_factory' in kw:
+                            pct_args['cursor_factory'] = kw['cursor_factory']
+
+                        _PsycopgConnectionTracing.__init__(self, **pct_args)
+                        factory.__init__(self, dsn, *a, **kw)
+
+                ConnectionFactory.__name__ = factory.__name__
+                _connection_factory_classes[factory] = ConnectionFactory
+
+        return _connection_factory_classes[factory](*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(cwd, 'README.rst')) as readme_file:
 
 # Keep these separated for tox extras
 test_requirements = ['mock', 'pytest']
-integration_test_requirements = ['docker', 'psycopg2', 'pymysql']
+integration_test_requirements = ['docker']
 
 setup(
     name='DBAPI-OpenTracing',
@@ -42,17 +42,17 @@ setup(
     platforms='any',
     license='Apache Software License v2',
     classifiers=[
-      'Development Status :: 4 - Beta',
-      'Intended Audience :: Developers',
-      'Natural Language :: English',
-      'License :: OSI Approved :: Apache Software License',
-      'Programming Language :: Python',
-      'Programming Language :: Python :: 2',
-      'Programming Language :: Python :: 2.7',
-      'Programming Language :: Python :: 3',
-      'Programming Language :: Python :: 3.4',
-      'Programming Language :: Python :: 3.5',
-      'Programming Language :: Python :: 3.6',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     install_requires=requirements,
     tests_require=test_requirements + integration_test_requirements,

--- a/tests/integration/psycopg2/initdb.d/db.sql
+++ b/tests/integration/psycopg2/initdb.d/db.sql
@@ -39,7 +39,7 @@ create or replace function test_function_two() returns test_type
 
 
 drop role if exists test_user;
-create role test_user with login password 'test_password';
+create role test_user with replication login password 'test_password';
 
 grant all privileges on database test_db TO test_user;
 grant all privileges on schema test_schema TO test_user;

--- a/tests/integration/test_psycopg2.py
+++ b/tests/integration/test_psycopg2.py
@@ -4,13 +4,15 @@ from time import sleep
 import os.path
 
 from opentracing.mocktracer import MockTracer
-from psycopg2.extras import DictCursor
+from psycopg2.extras import LogicalReplicationConnection, DictCursor, register_uuid
 from opentracing.ext import tags
+from psycopg2 import extensions
+import opentracing
 import psycopg2
 import docker
 import pytest
 
-from dbapi_opentracing import ConnectionTracing
+from dbapi_opentracing import PsycopgConnectionTracing
 from .conftest import DBAPITest
 
 
@@ -26,22 +28,31 @@ def postgres_container():
     try:
         yield postgres
     finally:
-        postgres.remove(force=True)
+        postgres.remove(v=True, force=True)
 
 
 class Psycopg2Test(DBAPITest):
 
     @pytest.fixture
     def connection_tracing(self, postgres_container):
-        while True:
+        tracer = MockTracer()
+        opentracing.tracer = tracer
+        for _ in range(240):
             try:
                 conn = psycopg2.connect(host='127.0.0.1', user='test_user', password='test_password',
-                                        dbname='test_db', port=5432, options='-c search_path=test_schema')
+                                        dbname='test_db', port=5432, options='-c search_path=test_schema',
+                                        connection_factory=lambda dsn: PsycopgConnectionTracing(
+                                            dsn, span_tags=dict(custom='tag'),
+                                            connection_factory=LogicalReplicationConnection,
+                                        ))
+                # Implicit C extension argument validation
+                assert isinstance(conn, extensions.connection)
+                extensions.register_type(extensions.UNICODE, conn)
+                extensions.register_type(extensions.UNICODEARRAY, conn)
                 break
             except psycopg2.OperationalError:
                 sleep(.25)
-        tracer = MockTracer()
-        return tracer, ConnectionTracing(conn, tracer, span_tags=dict(custom='tag'))
+        return tracer, conn
 
 
 class TestPsycopgCursorContext(Psycopg2Test):
@@ -50,18 +61,22 @@ class TestPsycopgCursorContext(Psycopg2Test):
         tracer, conn = connection_tracing
         with tracer.start_active_span('Parent'):
             with conn.cursor(cursor_factory=DictCursor) as cursor:
-                cursor.execute('insert into table_one values (%s, %s, %s, %s)',
+                # Test cursor extensions argument validation
+                register_uuid(None, cursor)
+                assert isinstance(cursor, extensions.cursor)
+                cursor.execute(b'insert into table_one values (%s, %s, %s, %s)',
                                (self.random_string(), self.random_string(),
                                 datetime.now(), datetime.now()))
-                cursor.execute('insert into table_two values (%s, %s, %s, %s)',
+                cursor.execute(u'insert into table_two values (%s, %s, %s, %s)',
                                (self.random_int(), self.random_int(),
                                 self.random_float(), self.random_float()))
             conn.commit()
         spans = tracer.finished_spans()
         assert len(spans) == 4
+
         first, second, commit, parent = spans
         for span in (first, second):
-            assert span.operation_name == 'DictCursor.execute(insert)'
+            assert span.operation_name == "DictCursor.execute(insert)"
             assert span.tags['custom'] == 'tag'
             assert span.tags[tags.DATABASE_TYPE] == 'sql'
             assert span.tags['db.rows_produced'] == 1
@@ -69,7 +84,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
             assert tags.ERROR not in span.tags
         assert first.tags[tags.DATABASE_STATEMENT] == 'insert into table_one values (%s, %s, %s, %s)'
         assert second.tags[tags.DATABASE_STATEMENT] == 'insert into table_two values (%s, %s, %s, %s)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_execute(self, connection_tracing):
@@ -97,7 +112,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_successful_executemany(self, connection_tracing):
@@ -127,7 +142,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
             assert tags.ERROR not in span.tags
         assert first.tags[tags.DATABASE_STATEMENT] == 'insert into table_one values (%s, %s, %s, %s)'
         assert second.tags[tags.DATABASE_STATEMENT] == 'insert into table_two values (%s, %s, %s, %s)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_executemany(self, connection_tracing):
@@ -157,7 +172,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_successful_callproc(self, connection_tracing):
@@ -180,7 +195,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
         assert second.tags[tags.DATABASE_STATEMENT] == 'test_function_two'
         assert first.operation_name == 'DictCursor.callproc(test_function_one)'
         assert second.operation_name == 'DictCursor.callproc(test_function_two)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_callproc(self, connection_tracing):
@@ -188,8 +203,8 @@ class TestPsycopgCursorContext(Psycopg2Test):
         with tracer.start_active_span('Parent'):
             with pytest.raises(psycopg2.ProgrammingError):
                 with conn.cursor(cursor_factory=DictCursor) as cursor:
-                    cursor.callproc('test_function_one')
-                    cursor.callproc('not_a_function')
+                    cursor.callproc(b'test_function_one')
+                    cursor.callproc(u'not_a_function')
             conn.commit()
         spans = tracer.finished_spans()
         assert len(spans) == 4
@@ -206,7 +221,7 @@ class TestPsycopgCursorContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
 
@@ -234,7 +249,7 @@ class TestPsycopgConnectionContext(Psycopg2Test):
             assert tags.ERROR not in span.tags
         assert first.tags[tags.DATABASE_STATEMENT] == 'insert into table_one values (%s, %s, %s, %s)'
         assert second.tags[tags.DATABASE_STATEMENT] == 'insert into table_two values (%s, %s, %s, %s)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_execute(self, connection_tracing):
@@ -261,7 +276,7 @@ class TestPsycopgConnectionContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert rollback.operation_name == 'connection.rollback()'
+        assert rollback.operation_name == 'LogicalReplicationConnection.rollback()'
         assert parent.operation_name == 'Parent'
 
     def test_successful_executemany(self, connection_tracing):
@@ -290,7 +305,7 @@ class TestPsycopgConnectionContext(Psycopg2Test):
             assert tags.ERROR not in span.tags
         assert first.tags[tags.DATABASE_STATEMENT] == 'insert into table_one values (%s, %s, %s, %s)'
         assert second.tags[tags.DATABASE_STATEMENT] == 'insert into table_two values (%s, %s, %s, %s)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_executemany(self, connection_tracing):
@@ -319,7 +334,7 @@ class TestPsycopgConnectionContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert rollback.operation_name == 'connection.rollback()'
+        assert rollback.operation_name == 'LogicalReplicationConnection.rollback()'
         assert parent.operation_name == 'Parent'
 
     def test_successful_callproc(self, connection_tracing):
@@ -341,7 +356,7 @@ class TestPsycopgConnectionContext(Psycopg2Test):
         assert second.tags[tags.DATABASE_STATEMENT] == 'test_function_two'
         assert first.operation_name == 'cursor.callproc(test_function_one)'
         assert second.operation_name == 'cursor.callproc(test_function_two)'
-        assert commit.operation_name == 'connection.commit()'
+        assert commit.operation_name == 'LogicalReplicationConnection.commit()'
         assert parent.operation_name == 'Parent'
 
     def test_unsuccessful_callproc(self, connection_tracing):
@@ -366,5 +381,5 @@ class TestPsycopgConnectionContext(Psycopg2Test):
         assert 'db.rows_produced' not in second.tags
         assert tags.ERROR not in first.tags
         assert second.tags[tags.ERROR] is True
-        assert rollback.operation_name == 'connection.rollback()'
+        assert rollback.operation_name == 'LogicalReplicationConnection.rollback()'
         assert parent.operation_name == 'Parent'

--- a/tests/integration/test_pymysql.py
+++ b/tests/integration/test_pymysql.py
@@ -29,14 +29,14 @@ def mysql_container():
     try:
         yield mysql
     finally:
-        mysql.remove(force=True)
+        mysql.remove(v=True, force=True)
 
 
 class PyMySQLTest(DBAPITest):
 
     @pytest.fixture
     def connection_tracing(self, mysql_container):
-        while True:
+        for _ in range(240):
             try:
                 conn = pymysql.connect(host='127.0.0.1', user='test_user', password='test_password',
                                        db='test_db', port=3306, cursorclass=DictCursor)
@@ -53,7 +53,7 @@ class TestPyMYSQLCursorContext(PyMySQLTest):
         tracer, conn = connection_tracing
         with tracer.start_active_span('Parent'):
             with conn.cursor() as cursor:
-                cursor.execute('insert into table_one values (%s, %s, %s, %s)',
+                cursor.execute(u'insert into table_one values (%s, %s, %s, %s)',
                                (self.random_string(), self.random_string(),
                                 datetime.now(), datetime.now()))
                 cursor.execute('insert into table_two values (%s, %s, %s, %s)',
@@ -168,7 +168,7 @@ class TestPyMYSQLCursorContext(PyMySQLTest):
         with tracer.start_active_span('Parent'):
             with conn.cursor() as cursor:
                 cursor.callproc('test_procedure_one')
-                cursor.callproc('test_procedure_two')
+                cursor.callproc(u'test_procedure_two')
             conn.commit()
         spans = tracer.finished_spans()
         assert len(spans) == 4

--- a/tests/unit/test_psycopg2.py
+++ b/tests/unit/test_psycopg2.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+#  Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+
+import types
+
+from opentracing.mocktracer import MockTracer
+from opentracing.ext import tags
+from mock import Mock, patch
+import pytest
+
+from dbapi_opentracing.psycopg2_tracing import PsycopgConnectionTracing
+
+row_count = 'SomeRowCount'
+
+
+class SomeException(Exception):
+    pass
+
+
+class MockDBAPICursor(object):
+    execute = Mock(spec=types.MethodType)
+    execute.__name__ = 'execute'
+
+    executemany = Mock(spec=types.MethodType)
+    executemany.__name__ = 'executemany'
+
+    callproc = Mock(spec=types.MethodType)
+    callproc.__name__ = 'callproc'
+
+    rowcount = row_count
+
+    def __init__(self, conn, name=None):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return self
+
+
+class MockDBAPIConnection(object):
+    commit = Mock(spec=types.MethodType)
+    commit.__name__ = 'commit'
+
+    rollback = Mock(spec=types.MethodType)
+    rollback.__name__ = 'rollback'
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __exit__(self, exc, value, tb):
+        if exc:
+            return self.rollback()
+        return self.commit()
+
+
+class DBAPITestSuite(object):
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.tracer = MockTracer()
+        self.connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer,
+                                                   connection_factory=MockDBAPIConnection,
+                                                   cursor_factory=MockDBAPICursor)
+        assert isinstance(self.connection, MockDBAPIConnection)
+
+
+class TestPsycopgConnectionTracingCursorContext(DBAPITestSuite):
+
+    def test_execute_is_traced(self):
+        statement = u'SELECT ጫ FROM SOME_TABLE'
+        with self.connection.cursor(cursor_factory=MockDBAPICursor) as cursor:
+            assert isinstance(cursor, MockDBAPICursor)
+            cursor.execute(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans.pop()
+        assert span.operation_name == 'MockDBAPICursor.execute(SELECT)'
+        assert span.tags[tags.DATABASE_TYPE] == 'sql'
+        assert span.tags[tags.DATABASE_STATEMENT] == statement
+        assert span.tags['db.rows_produced'] == row_count
+
+    def test_executemany_is_traced(self):
+        statement = 'DROP DB'
+        with self.connection.cursor(cursor_factory=MockDBAPICursor) as cursor:
+            cursor.executemany(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans.pop()
+        assert span.operation_name == 'MockDBAPICursor.executemany(DROP)'
+        assert span.tags[tags.DATABASE_TYPE] == 'sql'
+        assert span.tags[tags.DATABASE_STATEMENT] == statement
+        assert span.tags['db.rows_produced'] == row_count
+
+    def test_callproc_is_traced(self):
+        procedure = 'my_procedure'
+        with self.connection.cursor(cursor_factory=MockDBAPICursor) as cursor:
+            cursor.callproc(procedure)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 1
+        span = spans.pop()
+        assert span.operation_name == 'MockDBAPICursor.callproc(my_procedure)'
+        assert span.tags[tags.DATABASE_TYPE] == 'sql'
+        assert span.tags[tags.DATABASE_STATEMENT] == procedure
+        assert span.tags['db.rows_produced'] == row_count
+
+
+class TestPsycopgConnectionTracingCursorWhitelist(DBAPITestSuite):
+
+    def test_execute_is_not_traced(self):
+        with self.connection.cursor(cursor_factory=MockDBAPICursor, trace_execute=False) as cursor:
+            cursor.execute('SELECT * FROM SOME_TABLE')
+        assert not self.tracer.finished_spans()
+
+    def test_executemany_is_not_traced(self):
+        with self.connection.cursor(cursor_factory=MockDBAPICursor, trace_executemany=False) as cursor:
+            cursor.executemany('DROP DB')
+        assert not self.tracer.finished_spans()
+
+    def test_callproc_is_not_traced(self):
+        with self.connection.cursor(cursor_factory=MockDBAPICursor, trace_callproc=False) as cursor:
+            cursor.callproc('my_procedure')
+        assert not self.tracer.finished_spans()
+
+
+class TestPsycopgConnectionTracingConnectionContext(DBAPITestSuite):
+
+    def test_execute_and_commit_are_traced(self):
+        statement = 'SELECT * FROM SOME_TABLE'
+        with self.connection as cursor:
+            assert isinstance(cursor, MockDBAPICursor)
+            cursor.execute(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        execute, commit = spans
+        assert execute.operation_name == 'MockDBAPICursor.execute(SELECT)'
+        assert execute.tags[tags.DATABASE_TYPE] == 'sql'
+        assert execute.tags[tags.DATABASE_STATEMENT] == statement
+        assert execute.tags['db.rows_produced'] == row_count
+        assert commit.operation_name == 'MockDBAPIConnection.commit()'
+        assert commit.tags == {tags.DATABASE_TYPE: 'sql'}
+
+    def test_executemany_and_commit_are_traced(self):
+        statement = 'INSERT INTO some_table VALUES (%s, %s, %s)'
+        with self.connection as cursor:
+            cursor.executemany(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        executemany, commit = spans
+        assert executemany.operation_name == 'MockDBAPICursor.executemany(INSERT)'
+        assert executemany.tags[tags.DATABASE_TYPE] == 'sql'
+        assert executemany.tags[tags.DATABASE_STATEMENT] == statement
+        assert executemany.tags['db.rows_produced'] == row_count
+        assert commit.operation_name == 'MockDBAPIConnection.commit()'
+        assert commit.tags == {tags.DATABASE_TYPE: 'sql'}
+
+    def test_callproc_and_commit_are_traced(self):
+        with self.connection as cursor:
+            cursor.callproc(b'my_procedure')
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        callproc, commit = spans
+        assert callproc.operation_name == 'MockDBAPICursor.callproc(my_procedure)'
+        assert callproc.tags[tags.DATABASE_TYPE] == 'sql'
+        assert callproc.tags[tags.DATABASE_STATEMENT] == 'my_procedure'
+        assert callproc.tags['db.rows_produced'] == row_count
+        assert commit.operation_name == 'MockDBAPIConnection.commit()'
+        assert commit.tags == {tags.DATABASE_TYPE: 'sql'}
+
+    def test_execute_and_rollback_are_traced(self):
+        statement = 'SELECT * FROM some_table'
+        with self.connection as cursor:
+            with patch.object(MockDBAPICursor, 'execute', side_effect=SomeException()) as execute:
+                execute.__name__ = 'execute'
+                cursor.execute(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        execute, rollback = spans
+        assert execute.operation_name == 'MockDBAPICursor.execute(SELECT)'
+        assert execute.tags[tags.DATABASE_TYPE] == 'sql'
+        assert execute.tags[tags.DATABASE_STATEMENT] == statement
+        assert execute.tags[tags.ERROR] is True
+        assert 'db.rows_produced' not in execute.tags
+        assert 'SomeException' in execute.logs[0].key_values['error.object']
+        assert rollback.operation_name == 'MockDBAPIConnection.rollback()'
+        assert rollback.tags == {tags.DATABASE_TYPE: 'sql'}
+
+    def test_executemany_and_rollback_are_traced(self):
+        statement = u'INSERT INTO some_table VALUES (%s, %s, %s)'
+        with self.connection as cursor:
+            with patch.object(MockDBAPICursor, 'executemany', side_effect=SomeException()) as executemany:
+                executemany.__name__ = 'executemany'
+                cursor.executemany(statement)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        executemany, rollback = spans
+        assert executemany.operation_name == 'MockDBAPICursor.executemany(INSERT)'
+        assert executemany.tags[tags.DATABASE_TYPE] == 'sql'
+        assert executemany.tags[tags.DATABASE_STATEMENT] == statement
+        assert executemany.tags[tags.ERROR] is True
+        assert 'db.rows_produced' not in executemany.tags
+        assert 'SomeException' in executemany.logs[0].key_values['error.object']
+
+    def test_callproc_and_rollback_are_traced(self):
+        procedure = b'\x80my_procedure'  # invalid start byte
+        expected = b'\x80my_procedure'.decode('utf-8', 'replace')
+        with self.connection as cursor:
+            with patch.object(MockDBAPICursor, 'callproc', side_effect=SomeException()) as callproc:
+                callproc.__name__ = 'callproc'
+                cursor.callproc(procedure)
+        spans = self.tracer.finished_spans()
+        assert len(spans) == 2
+        callproc, rollback = spans
+        assert callproc.operation_name == u'MockDBAPICursor.callproc({})'.format(expected)
+        assert callproc.tags[tags.DATABASE_TYPE] == 'sql'
+        assert callproc.tags[tags.DATABASE_STATEMENT] == expected
+        assert callproc.tags[tags.ERROR] is True
+        assert 'db.rows_produced' not in callproc.tags
+        assert 'SomeException' in callproc.logs[0].key_values['error.object']
+        assert rollback.operation_name == 'MockDBAPIConnection.rollback()'
+        assert rollback.tags == {tags.DATABASE_TYPE: 'sql'}
+
+
+class TestPsycopgConnectionTracingConnectionContextWhitelist(DBAPITestSuite):
+
+    def test_execute_and_commit_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_execute=False,
+                                              trace_commit=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            cursor.execute('SELECT * FROM SOME_TABLE')
+        assert not self.tracer.finished_spans()
+
+    def test_executemany_and_commit_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_executemany=False,
+                                              trace_commit=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            cursor.executemany('INSERT INTO some_table VALUES (%s, %s, %s)')
+        assert not self.tracer.finished_spans()
+
+    def test_callproc_and_commit_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_callproc=False,
+                                              trace_commit=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            cursor.callproc('my_procedure')
+        assert not self.tracer.finished_spans()
+
+    def test_execute_and_rollback_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_execute=False,
+                                              trace_rollback=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            with patch.object(MockDBAPICursor, 'execute', side_effect=SomeException()) as execute:
+                execute.__name__ = 'execute'
+                cursor.execute('SELECT * FROM some_table')
+        assert not self.tracer.finished_spans()
+
+    def test_executemany_and_rollback_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_executemany=False,
+                                              trace_rollback=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            with patch.object(MockDBAPICursor, 'executemany', side_effect=SomeException()) as executemany:
+                executemany.__name__ = 'executemany'
+                cursor.executemany('INSERT INTO some_table VALUES (%s, %s, %s)')
+        assert not self.tracer.finished_spans()
+
+    def test_callproc_and_rollback_are_not_traced(self):
+        connection = PsycopgConnectionTracing('dbname=test', tracer=self.tracer, trace_callproc=False,
+                                              trace_rollback=False, connection_factory=MockDBAPIConnection,
+                                              cursor_factory=MockDBAPICursor)
+        with connection as cursor:
+            with patch.object(MockDBAPICursor, 'callproc', side_effect=SomeException()) as callproc:
+                callproc.__name__ = 'callproc'
+                cursor.callproc('my_procedure')
+        assert not self.tracer.finished_spans()
+
+
+class TestPsycopgConnectionTracing(object):
+
+    def test_custom_span_tags(self):
+        span_tags = dict(one=123, two=234)
+        tracer = MockTracer()
+        connection = PsycopgConnectionTracing('dbname=test', tracer=tracer, span_tags=span_tags,
+                                              connection_factory=MockDBAPIConnection, cursor_factory=MockDBAPICursor)
+
+        with connection as cursor:
+            cursor.execute('insert')
+            cursor.executemany('insert', [1, 2])
+            cursor.callproc('procedure')
+
+        spans = tracer.finished_spans()
+        assert len(spans) == 4
+        for span in spans:
+            assert span.tags[tags.DATABASE_TYPE] == 'sql'
+            assert span.tags['one'] == 123
+            assert span.tags['two'] == 234

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{27,34,35,36}-unit
     py{27,34,35,36}-pymysql{08,09}
     py{27,34,35,36}-psycopg2-27
+    py{27,34,35,36}-psycopg2-binary-27
 
 [testenv]
 basepython =
@@ -16,9 +17,11 @@ passenv = PYTHONPATH
 setenv = PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
 deps =
     flake8: flake8
+    unit: psycopg2>=2.7,<2.8
     pymysql08: pymysql>=0.08,<0.09
     pymysql09: pymysql>=0.09,<0.10
     psycopg2-27: psycopg2>=2.7,<2.8
+    psycopg2-binary-27: psycopg2-binary>=2.7,<2.8
 extras =
     py{27,34,35,36}: unit_tests
     pymysql{08,09}: integration_tests
@@ -27,7 +30,7 @@ commands =
     flake8: flake8 setup.py dbapi_opentracing tests
     py{27,34,35,36}-unit: pytest tests/unit
     pymysql{08,09}: pytest tests/integration/test_pymysql.py
-    psycopg2-27: pytest tests/integration/test_psycopg2.py
+    psycopg2: pytest tests/integration/test_psycopg2.py
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
`ConnectionTracing` and `CursorTracing` fail C argument validation in psycopg2 extensions/extras because they aren't proper subclasses of their respective types.  These changes introduce
`PsycopgConnectionTracing` and an associated `PsycopgCursorTracing` cursor class generation mechanism to provide support for `connection_factory` and `cursor_factory`: http://initd.org/psycopg/docs/extras.html#cursor-subclasses

Changes also include integration test addition for the psycopg2-binary package and stop leaking docker volumes.