### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/dbapi_opentracing/tracing.py
+++ b/dbapi_opentracing/tracing.py
@@ -42,10 +42,12 @@ class _ConnectionTracing(object):
 
             try:
                 val = func(*args, **kwargs)
-            except Exception:
+            except Exception as e:
                 span.set_tag(tags.ERROR, True)
-                span.log_kv({'event': 'error',
-                             'error.object': traceback.format_exc()})
+                span.set_tag('sfx.error.message', str(e))
+                span.set_tag('sfx.error.object', str(e.__class__))
+                span.set_tag('sfx.error.kind', e.__class__.__name__)
+                span.set_tag('sfx.error.stack', traceback.format_exc())
                 raise
             return val
 
@@ -143,10 +145,12 @@ class _Cursor(object):
 
             try:
                 val = func(*args, **kwargs)
-            except Exception:
+            except Exception as e:
                 span.set_tag(tags.ERROR, True)
-                span.log_kv({'event': 'error',
-                             'error.object': traceback.format_exc()})
+                span.set_tag('sfx.error.message', str(e))
+                span.set_tag('sfx.error.object', str(e.__class__))
+                span.set_tag('sfx.error.kind', e.__class__.__name__)
+                span.set_tag('sfx.error.stack', traceback.format_exc())
                 raise
             span.set_tag('db.rows_produced', self.rowcount)
         return val

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -165,9 +165,10 @@ class TestConnectionTracingConnectionContext(DBAPITestSuite):
         assert commit.operation_name == 'MockDBAPIConnection.commit()'
 
     def test_execute_and_rollback_are_traced(self):
+        error = SomeException('message')
         statement = 'SELECT * FROM some_table'
         with self.connection as cursor:
-            with patch.object(MockDBAPICursor, 'execute', side_effect=SomeException()) as execute:
+            with patch.object(MockDBAPICursor, 'execute', side_effect=error) as execute:
                 execute.__name__ = 'execute'
                 cursor.execute(statement)
         spans = self.tracer.finished_spans()
@@ -179,13 +180,18 @@ class TestConnectionTracingConnectionContext(DBAPITestSuite):
         assert execute.tags[tags.DATABASE_STATEMENT] == statement
         assert execute.tags[tags.ERROR] is True
         assert 'db.rows_produced' not in execute.tags
-        assert 'SomeException' in execute.logs[0].key_values['error.object']
+
+        assert execute.tags['sfx.error.kind'] == 'SomeException'
+        assert execute.tags['sfx.error.message'] == 'message'
+        assert execute.tags['sfx.error.object'] == str(error.__class__)
+        assert len(execute.tags['sfx.error.stack']) > 50
         assert rollback.operation_name == 'MockDBAPIConnection.rollback()'
 
     def test_executemany_and_rollback_are_traced(self):
         statement = 'INSERT INTO some_table VALUES (%s, %s, %s)'
+        error = SomeException('message')
         with self.connection as cursor:
-            with patch.object(MockDBAPICursor, 'executemany', side_effect=SomeException()) as executemany:
+            with patch.object(MockDBAPICursor, 'executemany', side_effect=error) as executemany:
                 executemany.__name__ = 'executemany'
                 cursor.executemany(statement)
         spans = self.tracer.finished_spans()
@@ -197,13 +203,17 @@ class TestConnectionTracingConnectionContext(DBAPITestSuite):
         assert executemany.tags[tags.DATABASE_STATEMENT] == statement
         assert executemany.tags[tags.ERROR] is True
         assert 'db.rows_produced' not in executemany.tags
-        assert 'SomeException' in executemany.logs[0].key_values['error.object']
+        assert executemany.tags['sfx.error.kind'] == 'SomeException'
+        assert executemany.tags['sfx.error.message'] == 'message'
+        assert executemany.tags['sfx.error.object'] == str(error.__class__)
+        assert len(executemany.tags['sfx.error.stack']) > 50
         assert rollback.operation_name == 'MockDBAPIConnection.rollback()'
 
     def test_callproc_and_rollback_are_traced(self):
         procedure = 'my_procedure'
+        error = SomeException('message')
         with self.connection as cursor:
-            with patch.object(MockDBAPICursor, 'callproc', side_effect=SomeException()) as callproc:
+            with patch.object(MockDBAPICursor, 'callproc', side_effect=error) as callproc:
                 callproc.__name__ = 'callproc'
                 cursor.callproc(procedure)
         spans = self.tracer.finished_spans()
@@ -215,7 +225,10 @@ class TestConnectionTracingConnectionContext(DBAPITestSuite):
         assert callproc.tags[tags.DATABASE_STATEMENT] == procedure
         assert callproc.tags[tags.ERROR] is True
         assert 'db.rows_produced' not in callproc.tags
-        assert 'SomeException' in callproc.logs[0].key_values['error.object']
+        assert callproc.tags['sfx.error.kind'] == 'SomeException'
+        assert callproc.tags['sfx.error.message'] == 'message'
+        assert callproc.tags['sfx.error.object'] == str(error.__class__)
+        assert len(callproc.tags['sfx.error.stack']) > 50
         assert rollback.operation_name == 'MockDBAPIConnection.rollback()'
 
 


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.